### PR TITLE
Update Dependencies, Plugins and Java to 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>ber-tlv</artifactId>
     <version>1.0-9-SNAPSHOT</version>
 
-    <name>ber-tlv  ${version}</name>
+    <name>ber-tlv ${project.version}</name>
 
     <description>BER-TLV reader and writer</description>
 
@@ -60,20 +60,20 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.12</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.6</version>
+            <version>1.7.25</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.6</version>
+            <version>1.7.25</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -83,10 +83,10 @@
                 <inherited>true</inherited>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.7.0</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                     <debug>true</debug>
                 </configuration>
             </plugin>
@@ -110,7 +110,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.1</version>
+                        <version>1.6</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Some of the ancient dependencies and plugins were updated and the Java
version to 6 (the maven compiler complained that it cannot build with 5
anymore). Also the plugins are now with their most recent version.

This also moves junit to the test scope. (This is actually pretty bad since it packages the junit dependency in production if you use this lib)