### PR TITLE
Add ber tag factory to parser to allow custom tag creation.

### DIFF
--- a/src/main/java/com/payneteasy/tlv/BerTagFactory.java
+++ b/src/main/java/com/payneteasy/tlv/BerTagFactory.java
@@ -1,0 +1,5 @@
+package com.payneteasy.tlv;
+
+public interface BerTagFactory {
+	BerTag createTag(byte[] aBuf, int aOffset, int aLength);
+}

--- a/src/main/java/com/payneteasy/tlv/BerTlvParser.java
+++ b/src/main/java/com/payneteasy/tlv/BerTlvParser.java
@@ -9,16 +9,28 @@ import java.util.List;
  */
 public class BerTlvParser {
 
+	private static final BerTagFactory DEFAULT_TAG_FACTORY = new DefaultBerTagFactory();
+
+	private final BerTagFactory tagFactory;
     private final IBerTlvLogger log;
 
     public BerTlvParser() {
-        this(EMPTY_LOGGER);
+        this(DEFAULT_TAG_FACTORY, EMPTY_LOGGER);
     }
 
     public BerTlvParser(IBerTlvLogger aLogger) {
-        log = aLogger;
+    	this(DEFAULT_TAG_FACTORY, aLogger);
     }
-
+    
+    public BerTlvParser(BerTagFactory aTagFactory) {
+    	this(aTagFactory, EMPTY_LOGGER);
+    }
+    
+    public BerTlvParser(BerTagFactory aTagFactory, IBerTlvLogger aLogger) {
+    	tagFactory = aTagFactory;
+    	log = aLogger;
+    }
+    
     public BerTlv parseConstructed(byte[] aBuf) {
         return parseConstructed(aBuf, 0, aBuf.length);
     }
@@ -164,7 +176,7 @@ public class BerTlvParser {
         if(log.isDebugEnabled()) {
             log.debug("{}Creating tag {}...", aLevelPadding, HexUtil.toFormattedHexString(aBuf, aOffset, aLength));
         }
-        return new BerTag(aBuf, aOffset, aLength);
+        return tagFactory.createTag(aBuf, aOffset, aLength);
     }
 
     private int getTagBytesCount(byte[] aBuf, int aOffset) {

--- a/src/main/java/com/payneteasy/tlv/DefaultBerTagFactory.java
+++ b/src/main/java/com/payneteasy/tlv/DefaultBerTagFactory.java
@@ -1,0 +1,10 @@
+package com.payneteasy.tlv;
+
+public class DefaultBerTagFactory implements BerTagFactory {
+
+	@Override
+	public BerTag createTag(byte[] aBuf, int aOffset, int aLength) {
+		return new BerTag(aBuf, aOffset, aLength);
+	}
+
+}


### PR DESCRIPTION
Hi,

We are dealing with an errornous ber tlv data that is defined by GlobalPlatform.
GlobalPlatform used 'B0' and 'F0' tags for primitive tlv however since their contructed bit is set,
ber-tlv rightfully fails to parse them. Since Globalplatform decided to not to fix them, we need a way to handle these tags. I thought, if ber-tlv parser takes a tag factory, then we can write a custom tag factory to handle them. Therefore I added an interface and a default factory. Could you please review it and if it is OK for you, could you please add it to the project? Currently, there is no way to override the parsing behaviour.

This may help to cope with data that was designed errornously such as
GlobalPlatform public key data which has 'B0' and 'F0' tags which are
not valid. Explanation from document [1] - Table 3-8:
GlobalPlatform acknowledges as an error that values 'B0' and 'F0' in the table above are not
valid ASN.1 tag values. This mistake was introduced in previous versions of this specification.
Although this may be a problem for standard tools used to edit or display certificates and ASN.1
structures in general, it’s been decided, for the moment at least, to keep such values to preserve
backward compatibility with existing implementations already coping with such errors.

[1] https://globalplatform.org/wp-content/uploads/2019/07/GPC_2.3_A_ConfidentialCardContentMgmt_v1.2_PublicRelease-replacement.pdf